### PR TITLE
docs: add Sablier under "Use Dai"

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ Participate in MakerDAO Governance by staying informed and voting regularly.
 - [PoolTogether](https://www.pooltogether.us/): Lossless Lottery
 - [Pool Dai](https://zeframlou.github.io/pooldai/): Lossless Donation Protocol
 - [Request](https://app.request.network/): Request a Payment in Dai
+- [Sablier](https://pay.sablier.finance): Stream Money with Dai
 - [Whisp.Money](https://whisp.money): Dai Payroll Solution
 
 #### Merchant Solutions | Payment Processors


### PR DESCRIPTION
Adds a link for our money streaming [dapp](https://pay.sablier.finance) - DAI is the default ERC-20 that we show to users:

![Capture d’écran 2020-06-08 à 21 03 32](https://user-images.githubusercontent.com/8782666/84064622-99ae1780-a9cb-11ea-9347-4ca5acfa2bb6.png)
