### PR TITLE
Add Atstake as a site where you can use DAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ Participate in MakerDAO Governance by staying informed and voting regularly.
 
 #### Apps | Integrations | Tools
 
+- [Atstake](https://atstake.net/): Marketplace and Platform for Contract Enforcement
 - [Bounty0x](https://bounty0x.io/): Bounty Hunting Platform
 - [Bounties Network](https://bounties.network/): Platform to Create Projects, Collaborate, and Freelance
 - [Chai](https://chai.money/): ERC-20 wrapper for Dai in DSR


### PR DESCRIPTION
Atstake is an online marketplace similar to Haven/OpenBazaar except contracts can be more general (both people can stake money on a contract) and unlike Haven you can use DAI with Atstake. 

Here's the site: https://atstake.net/
Here's the launch announcement: https://twitter.com/elliot_olds/status/1174410109557956608